### PR TITLE
[fix] database/sql の import を削除

### DIFF
--- a/dbconnection/dbconnection.go
+++ b/dbconnection/dbconnection.go
@@ -1,7 +1,6 @@
 package dbconnection
 
 import (
-	"database/sql"
 	"fmt"
 	"log"
 


### PR DESCRIPTION
dbconnection では直接使用はしていないため